### PR TITLE
slackのpublicチャンネル取得数が足りないので1000に引き上げ

### DIFF
--- a/summarizer.py
+++ b/summarizer.py
@@ -58,6 +58,7 @@ try:
     channels_info = client.conversations_list(
         types="public_channel",
         exclude_archived=True,
+        limit=1000
     )
     channels = [channel for channel in channels_info['channels']
                 if not channel["is_archived"] and channel["is_channel"]]


### PR DESCRIPTION
publicチャンネル数が100を超えるため、全チャンネルの情報を取得できていませんでした。
MAX値の1000を指定するようにしました。

https://api.slack.com/methods/conversations.list#arg_limit