### PR TITLE
display_nameを使う

### DIFF
--- a/lib/slack.py
+++ b/lib/slack.py
@@ -144,7 +144,7 @@ class SlackClient:
             None
         """
         matching_users = [user for user in self.users if user['id'] == user_id]
-        return matching_users[0]['name'] if len(matching_users) > 0 else None
+        return matching_users[0]['profile']['display_name'] if len(matching_users) > 0 else None
 
     def replace_user_id_with_name(self, body_text: str) -> str:
         """ Replace user IDs in a chat message text with user names.


### PR DESCRIPTION
nameではなくdisplay_nameを使うようにしてみました

> name
> String
> Don't use this. It once indicated the preferred username for a user, but that behavior has [fundamentally changed](https://api.slack.com/changelog/2017-09-the-one-about-usernames) since.
>
> display_name
> String
> The display name the user has chosen to identify themselves by in their workspace profile. Do not use this field as a unique identifier for a user, as it may change at any time. Instead, use id and team_id in concert.




user type | Slack
https://api.slack.com/types/user

