### PR TITLE
Misc fix

### DIFF
--- a/lib/slack.py
+++ b/lib/slack.py
@@ -111,7 +111,7 @@ class SlackClient:
             # Get speaker name
             speaker_name = self.get_user_name(message["user"]) or "somebody"
 
-            # Get message body fro result dict.
+            # Get message body from result dict.
             body_text = message["text"].replace("\n", "\\n")
 
             # Replace User IDs in a chat message text with user names.

--- a/lib/slack.py
+++ b/lib/slack.py
@@ -42,7 +42,6 @@ class SlackClient:
             channel_id (str): The ID of the channel to retrieve the chat history for.
             start_time (datetime): The start time of the time range to retrieve chat history for.
             end_time (datetime): The end time of the time range to retrieve chat history for.
-            users (list): A list of dictionaries containing information about each user in the Slack workspace.
 
         Returns:
             list: A list of chat messages from the specified channel, in the format "Speaker: Message".

--- a/lib/slack.py
+++ b/lib/slack.py
@@ -11,11 +11,12 @@ class SlackClient:
     """ A class for managing a Slack bot client.
 
     Args:
-        token (str): The Slack Bot token used to authenticate with the Slack API.
+        slack_api_token (str): The Slack Bot token used to authenticate with the Slack API.
+        summary_channel (str): The Slack channel ID where the summary is posted.
 
     Example:
         ```
-        client = SlackClient(SLACK_BOT_TOKEN)
+        client = SlackClient(SLACK_BOT_TOKEN, SUMMARY_CHANNEL_ID)
         client.postSummary(text)
         ```
     """
@@ -59,8 +60,8 @@ class SlackClient:
             self._wait_api_call()
             result = retry(lambda: self.client.conversations_history(
                 channel=channel_id,
-                oldest=start_time.timestamp(),
-                latest=end_time.timestamp(),
+                oldest=str(start_time.timestamp()),
+                latest=str(end_time.timestamp()),
                 limit=1000),
                            exception=SlackApiError)
             messages_info.extend(result["messages"])
@@ -77,8 +78,8 @@ class SlackClient:
 
                 result = retry(lambda: self.client.conversations_history(
                     channel=channel_id,
-                    oldest=start_time.timestamp(),
-                    latest=end_time.timestamp(),
+                    oldest=str(start_time.timestamp()),
+                    latest=str(end_time.timestamp()),
                     limit=1000),
                                exception=SlackApiError)
             else:
@@ -89,8 +90,8 @@ class SlackClient:
             self._wait_api_call()
             result = retry(lambda: self.client.conversations_history(
                 channel=channel_id,
-                oldest=start_time.timestamp(),
-                latest=end_time.timestamp(),
+                oldest=str(start_time.timestamp()),
+                latest=str(end_time.timestamp()),
                 limit=1000,
                 cursor=result["response_metadata"]["next_cursor"]),
                            exception=SlackApiError)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -12,6 +12,7 @@ def retry(func, max_retries=5, sleep_time=10, exception=Exception):
         func (callable): The function to be wrapped.
         max_retries (int, optional): The maximum number of retries. Defaults to 5.
         sleep_time (int, optional): The sleep time in seconds between retries. Defaults to 10.
+        exception (Exception, optional): The expected exception class to catch and retry if raised. Defaults to Exception.
 
     Returns:
         result of func call.

--- a/summarizer.py
+++ b/summarizer.py
@@ -190,8 +190,8 @@ def runner():
         messages = list(map(remove_emoji, messages))
 
         result_text.append(f"----\n<#{channel['id']}>\n")
-        for spilitted_messages in split_messages_by_token_count(messages):
-            text = summarize("\n".join(spilitted_messages), LANGUAGE)
+        for splitted_messages in split_messages_by_token_count(messages):
+            text = summarize("\n".join(splitted_messages), LANGUAGE)
             result_text.append(text)
 
     title = (f"{start_time.strftime('%Y-%m-%d')} public channels summary\n\n")


### PR DESCRIPTION
Those are all trivial. PTAL when you have time:
- Fix typo: `spilitted` => `splitted`
- Fix docstring
- Cast to `str` when passing `oldest` and `latest` as per [the API doc](https://api.slack.com/methods/conversations.history)
    - It works even without this fix because the same value will be passed to Slack API in the end, whether they are `str` or `timestamp`. However, `mypy` would fail if you run it against the original code.